### PR TITLE
Add weekly expired promo scan

### DIFF
--- a/.github/scripts/report-expired-promos.mjs
+++ b/.github/scripts/report-expired-promos.mjs
@@ -63,7 +63,6 @@ const createIssueResponse = await fetch(
     body: JSON.stringify({
       title: issueTitle,
       body: issueBody,
-      labels: ["maintenance"],
     }),
   },
 );


### PR DESCRIPTION
## Summary
- add a script to detect expired promo entries
- add a GitHub Action to run the scan weekly and open an issue with expired promos
- add a helper to post the issue via the GitHub API

## Testing
- npm run lint
- npm run typecheck
- npm run validate
- npm run test

Fixes #10