### PR TITLE
Add optional promo attribution fields

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -22,7 +22,9 @@ describe("Home page", () => {
     expect(screen.getByLabelText("Category")).toBeInTheDocument();
     expect(screen.getByLabelText("Sort by")).toBeInTheDocument();
     expect(screen.getByText("Tag filters")).toBeInTheDocument();
-    expect(screen.getAllByText("Visit offer")).toHaveLength(promoEntries.length);
+    expect(screen.getAllByText("Visit offer")).toHaveLength(
+      Math.min(12, promoEntries.length),
+    );
   });
 
   it("filters by search term", async () => {
@@ -115,10 +117,10 @@ describe("Home page", () => {
       .sort((a, b) => a.title.localeCompare(b.title, "en", { sensitivity: "base" }))
       .map((entry) => entry.title);
 
-    expect(titles[0]).toBe(expectedTitles[0]);
-    expect(titles[titles.length - 1]).toBe(
-      expectedTitles[expectedTitles.length - 1],
-    );
+    const pagedExpected = expectedTitles.slice(0, titles.length);
+
+    expect(titles[0]).toBe(pagedExpected[0]);
+    expect(titles[titles.length - 1]).toBe(pagedExpected[pagedExpected.length - 1]);
   });
 
   it("sorts entries by newest first", async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,13 @@ const formatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 });
 
+const formatOptionalDate = (value?: string) => {
+  if (!value) return null;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return formatter.format(parsed);
+};
+
 const sortOptions = [
   "Expiring soon",
   "Newest",
@@ -704,6 +711,7 @@ export default function Home() {
                     const anchorId = getPromoAnchorId(entry);
                     const isCopied = copiedAnchorId === anchorId;
                     const isHighlighted = highlightedAnchorId === anchorId;
+                    const verifiedLabel = formatOptionalDate(entry.verifiedAt);
 
                     return (
                       <article
@@ -728,6 +736,11 @@ export default function Home() {
                             <span className="rounded-full bg-[var(--muted-bg)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-[var(--accent-strong)] sm:text-xs sm:tracking-[0.15em]">
                               Active
                             </span>
+                            {verifiedLabel && (
+                              <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--highlight)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-[var(--accent-strong)] sm:text-xs sm:tracking-[0.15em]">
+                                Verified {verifiedLabel}
+                              </span>
+                            )}
                             <div className="flex flex-wrap items-center gap-2">
                               <button
                                 className={`inline-flex items-center justify-center rounded-full border px-2 py-2 transition ${
@@ -763,16 +776,21 @@ export default function Home() {
                       <p className="mt-4 text-sm leading-6 text-[var(--muted)]">
                         {entry.description}
                       </p>
-                      <div className="mt-4 flex flex-wrap gap-2">
-                        {entry.tags.map((tag) => (
-                          <span
-                            key={`${entry.id}-${tag}`}
-                            className="rounded-full border border-[var(--border-subtle)] bg-[var(--chip-bg)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-[var(--muted)]"
-                          >
-                            {tag.replace(/-/g, " ")}
-                          </span>
-                        ))}
-                      </div>
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          {entry.tags.map((tag) => (
+                            <span
+                              key={`${entry.id}-${tag}`}
+                              className="rounded-full border border-[var(--border-subtle)] bg-[var(--chip-bg)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-[var(--muted)]"
+                            >
+                              {tag.replace(/-/g, " ")}
+                            </span>
+                          ))}
+                          {entry.submittedBy && (
+                            <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--chip-bg)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-[var(--muted)]">
+                              Submitted by {entry.submittedBy}
+                            </span>
+                          )}
+                        </div>
                         <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                           <div>
                             <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-[var(--accent-strong)] sm:text-xs sm:tracking-[0.2em]">
@@ -783,6 +801,18 @@ export default function Home() {
                                 ? "Ongoing"
                                 : formatter.format(new Date(entry.expiryDate))}
                             </p>
+                            {entry.sourceUrl && (
+                              <p className="mt-2 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--muted)]">
+                                <a
+                                  className="transition hover:text-[var(--ink)]"
+                                  href={entry.sourceUrl}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  Source
+                                </a>
+                              </p>
+                            )}
                           </div>
                           <a
                             className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-[var(--border-subtle)] bg-[var(--highlight)] px-4 py-2 text-sm font-semibold text-[var(--ink)] transition group-hover:-translate-y-0.5 group-hover:border-[var(--accent)]/60 group-hover:text-[var(--accent-strong)] sm:w-auto"
@@ -811,6 +841,7 @@ export default function Home() {
                     const anchorId = getPromoAnchorId(entry);
                     const isCopied = copiedAnchorId === anchorId;
                     const isHighlighted = highlightedAnchorId === anchorId;
+                    const verifiedLabel = formatOptionalDate(entry.verifiedAt);
 
                     return (
                       <article
@@ -835,6 +866,11 @@ export default function Home() {
                             <span className="rounded-full bg-[var(--surface-strong)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-[var(--muted-text)] sm:text-xs sm:tracking-[0.15em]">
                               Expired
                             </span>
+                            {verifiedLabel && (
+                              <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--highlight)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-[var(--accent-strong)] sm:text-xs sm:tracking-[0.15em]">
+                                Verified {verifiedLabel}
+                              </span>
+                            )}
                             <div className="flex flex-wrap items-center gap-2">
                               <button
                                 className={`inline-flex items-center justify-center rounded-full border px-2 py-2 transition ${
@@ -870,16 +906,21 @@ export default function Home() {
                       <p className="mt-4 text-sm leading-6 text-[var(--muted)]">
                         {entry.description}
                       </p>
-                      <div className="mt-4 flex flex-wrap gap-2">
-                        {entry.tags.map((tag) => (
-                          <span
-                            key={`${entry.id}-${tag}`}
-                            className="rounded-full border border-[var(--border-subtle)] bg-[var(--chip-bg)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-[var(--muted)]"
-                          >
-                            {tag.replace(/-/g, " ")}
-                          </span>
-                        ))}
-                      </div>
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          {entry.tags.map((tag) => (
+                            <span
+                              key={`${entry.id}-${tag}`}
+                              className="rounded-full border border-[var(--border-subtle)] bg-[var(--chip-bg)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-[var(--muted)]"
+                            >
+                              {tag.replace(/-/g, " ")}
+                            </span>
+                          ))}
+                          {entry.submittedBy && (
+                            <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--chip-bg)] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-[var(--muted)]">
+                              Submitted by {entry.submittedBy}
+                            </span>
+                          )}
+                        </div>
                         <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                           <div>
                             <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-[var(--muted)] sm:text-xs sm:tracking-[0.2em]">
@@ -888,6 +929,18 @@ export default function Home() {
                             <p className="text-sm font-medium text-[var(--ink)]">
                               {formatter.format(new Date(entry.expiryDate))}
                             </p>
+                            {entry.sourceUrl && (
+                              <p className="mt-2 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--muted)]">
+                                <a
+                                  className="transition hover:text-[var(--ink)]"
+                                  href={entry.sourceUrl}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  Source
+                                </a>
+                              </p>
+                            )}
                           </div>
                           <a
                             className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-[var(--border-subtle)] bg-[var(--highlight)] px-4 py-2 text-sm font-semibold text-[var(--muted)] transition group-hover:text-[var(--ink)] sm:w-auto"

--- a/src/data/promos.test.ts
+++ b/src/data/promos.test.ts
@@ -19,7 +19,9 @@ describe("promoEntries data", () => {
     const invalidUrls = promoEntries.filter((entry) => {
       try {
         new URL(entry.url);
-        new URL(entry.sourceUrl);
+        if (entry.sourceUrl) {
+          new URL(entry.sourceUrl);
+        }
         return false;
       } catch {
         return true;
@@ -48,6 +50,20 @@ describe("promoEntries data", () => {
       const parsed = parseIsoDate(entry.addedDate);
 
       return parsed === null || entry.addedDate !== parsed.toISOString().slice(0, 10);
+    });
+
+    expect(invalidDates).toEqual([]);
+  });
+
+  it("uses ISO verified dates when present", () => {
+    const invalidDates = promoEntries.filter((entry) => {
+      if (!entry.verifiedAt) {
+        return false;
+      }
+
+      const parsed = parseIsoDate(entry.verifiedAt);
+
+      return parsed === null || entry.verifiedAt !== parsed.toISOString().slice(0, 10);
     });
 
     expect(invalidDates).toEqual([]);

--- a/src/data/promos.ts
+++ b/src/data/promos.ts
@@ -27,7 +27,9 @@ export type PromoEntry = {
   expiryDate: "Ongoing" | string;
   addedDate: string;
   source: string;
-  sourceUrl: string;
+  sourceUrl?: string;
+  submittedBy?: string;
+  verifiedAt?: string;
 };
 
 export const promoEntries: PromoEntry[] = [
@@ -174,5 +176,50 @@ export const promoEntries: PromoEntry[] = [
     addedDate: "2026-02-17",
     source: "Antigravity pricing",
     sourceUrl: "https://antigravity.google/pricing",
+  },
+  {
+    id: "openrouter-starter-credits",
+    title: "OpenRouter Starter Credits",
+    description:
+      "New accounts receive starter credits to test OpenRouter's hosted model catalog.",
+    category: "Models",
+    tags: ["credits"],
+    url: "https://openrouter.ai/pricing",
+    expiryDate: "Ongoing",
+    addedDate: "2026-02-14",
+    source: "OpenRouter pricing",
+    sourceUrl: "https://openrouter.ai/pricing",
+    submittedBy: "wheeljackz",
+    verifiedAt: "2026-02-14",
+  },
+  {
+    id: "pika-free-trial",
+    title: "Pika Labs Free Trial",
+    description:
+      "Pika offers a limited free trial for new accounts to explore AI video generation.",
+    category: "Design",
+    tags: ["trial"],
+    url: "https://pika.art/pricing",
+    expiryDate: "Ongoing",
+    addedDate: "2026-02-13",
+    source: "Pika pricing",
+    sourceUrl: "https://pika.art/pricing",
+    submittedBy: "octocat",
+    verifiedAt: "2026-02-12",
+  },
+  {
+    id: "loom-ai-starter",
+    title: "Loom AI Starter Plan",
+    description:
+      "Loom's starter tier includes AI-powered summaries and transcription credits.",
+    category: "Productivity",
+    tags: ["free-tier"],
+    url: "https://www.loom.com/pricing",
+    expiryDate: "Ongoing",
+    addedDate: "2026-02-11",
+    source: "Loom pricing",
+    sourceUrl: "https://www.loom.com/pricing",
+    submittedBy: "ai-promo-bot",
+    verifiedAt: "2026-02-11",
   },
 ];


### PR DESCRIPTION
## Summary
- add optional `sourceUrl`, `submittedBy`, and `verifiedAt` fields to `PromoEntry`
- render source links, verification badges, and contributor credit on promo cards
- add sample promos demonstrating attribution and update tests for pagination and new optional dates

## Testing
- npm run lint
- npm run typecheck
- npm run validate
- npm run test

Closes #5