### PR TITLE
fix: add attribution for Antigravity Free Tier submission

### DIFF
--- a/src/data/promos.ts
+++ b/src/data/promos.ts
@@ -175,7 +175,8 @@ export const promoEntries: PromoEntry[] = [
     expiryDate: "Ongoing",
     addedDate: "2026-02-17",
     source: "Antigravity pricing",
-    sourceUrl: "https://antigravity.google/pricing",
+    sourceUrl: "https://github.com/zainfathoni/ai-promo/issues/30",
+    submittedBy: "ivankristianto",
   },
   {
     id: "openrouter-starter-credits",


### PR DESCRIPTION
Adds proper attribution for the Antigravity Free Tier promo that was submitted by @ivankristianto in #30.

Changes:
- `sourceUrl`: updated to point to the submission issue (#30) instead of the product pricing page
- `submittedBy`: `ivankristianto` — credits the community contributor

Closes #30