### PR TITLE
Add Ollama Free Tier promo

### DIFF
--- a/src/data/promos.ts
+++ b/src/data/promos.ts
@@ -401,6 +401,20 @@ export const promoEntries: PromoEntry[] = [
     sourceUrl: "https://aws.amazon.com/activate/",
   },
   {
+    id: "ollama-free-tier",
+    title: "Ollama Free Tier",
+    description:
+      "Free tier includes light usage for chat, quick questions, and trying out models. Currently minimax-m2.5:cloud and glm5:cloud are free to use with rate limit. Ollama can integrate with coding apps.",
+    category: "Models",
+    tags: ["free-tier"],
+    url: "https://ollama.com/pricing",
+    expiryDate: "Ongoing",
+    addedDate: "2026-02-18",
+    source: "Ollama",
+    sourceUrl: "https://ollama.com/pricing",
+    submittedBy: "ivankristianto",
+  },
+  {
     id: "microsoft-for-startups-founders-hub",
     title: "Microsoft for Startups Founders Hub",
     description:


### PR DESCRIPTION
## Summary

- Add Ollama Free Tier promo entry to the database
- Free tier includes light usage for chat, quick questions, and trying out models
- Currently minimax-m2.5:cloud and glm5:cloud are free to use with rate limit
- Ollama can integrate with coding apps

## Test plan

- [x] Run validation: `npm run validate`
- [x] Run lint: `npm run lint`
- [x] Run tests: `npm run test`