### PR TITLE
fix: use proper gh CLI flags in getSubmissionIssues

### DIFF
--- a/src/scripts/curate-promos.mts
+++ b/src/scripts/curate-promos.mts
@@ -55,8 +55,15 @@ function getRepoInfo(): { owner: string; name: string } {
 const { owner: REPO_OWNER, name: REPO_NAME } = getRepoInfo();
 
 function getSubmissionIssues(): Array<{ number: number; body: string; title: string; user: string }> {
-  const query = `repo:${REPO_OWNER}/${REPO_NAME} is:issue is:open label:promo label:submission`;
-  const output = gh(["search", "issues", "--limit", "100", "--json", "number,body,title,author", query]);
+  const output = gh([
+    "search", "issues",
+    "--repo", `${REPO_OWNER}/${REPO_NAME}`,
+    "--label", "promo",
+    "--label", "submission",
+    "--state", "open",
+    "--limit", "100",
+    "--json", "number,body,title,author",
+  ]);
   const issues = JSON.parse(output);
   return issues.map((issue: { number: number; body: string; title: string; author: { login: string } }) => ({
     number: issue.number,


### PR DESCRIPTION
## Problem

The curation script failed in CI with:

```
Error: Invalid search query "( repo:\"zainfathoni/ai-promo is:issue is:open label:promo label:submission\" ) type:issue"
```

The entire GitHub search query was being passed as a **positional argument** (keywords) to `gh search issues`. The CLI wraps it in quotes and appends `type:issue`, producing an invalid query that the GitHub search API rejects.

## Fix

Replace the raw query string with proper CLI flags:

```diff
- const query = `repo:${REPO_OWNER}/${REPO_NAME} is:issue is:open label:promo label:submission`;
- const output = gh(["search", "issues", "--limit", "100", "--json", "number,body,title,author", query]);
+ const output = gh([
+   "search", "issues",
+   "--repo", `${REPO_OWNER}/${REPO_NAME}`,
+   "--label", "promo",
+   "--label", "submission",
+   "--state", "open",
+   "--limit", "100",
+   "--json", "number,body,title,author",
+ ]);
```

## References

- Failed run: https://github.com/zainfathoni/ai-promo/actions/runs/22295102787/job/64490016619