### PR TITLE
fix: use CLI flags instead of raw query in getSubmissionIssues

### DIFF
--- a/src/scripts/curate-promos.mts
+++ b/src/scripts/curate-promos.mts
@@ -55,8 +55,17 @@ function getRepoInfo(): { owner: string; name: string } {
 const { owner: REPO_OWNER, name: REPO_NAME } = getRepoInfo();
 
 function getSubmissionIssues(): Array<{ number: number; body: string; title: string; user: string }> {
-  const query = `repo:${REPO_OWNER}/${REPO_NAME} is:issue is:open label:promo label:submission`;
-  const output = gh(["search", "issues", "--sort", "created", "--order", "asc", "--limit", "100", "--json", "number,body,title,author", query]);
+  const output = gh([
+    "search", "issues",
+    "--repo", `${REPO_OWNER}/${REPO_NAME}`,
+    "--label", "promo",
+    "--label", "submission",
+    "--state", "open",
+    "--sort", "created",
+    "--order", "asc",
+    "--limit", "100",
+    "--json", "number,body,title,author",
+  ]);
   const issues = JSON.parse(output);
   return issues.map((issue: { number: number; body: string; title: string; author: { login: string } }) => ({
     number: issue.number,


### PR DESCRIPTION
## Problem

The curation script keeps failing with:

```
Error: Invalid search query
"( repo:"zainfathoni/ai-promo is:issue is:open label:promo label:submission" ) type:issue"
```

`gh search issues` wraps the positional arg in quotes, so `is:open label:promo label:submission` ends up _inside_ the `repo:` value.

This was supposed to be fixed in #49, but PR #49 was squash-merged at the first commit (sort fix only) — the CLI flags commit was pushed to the branch _after_ the merge, so it never landed on main.

## Fix

Replace the raw query string with proper CLI flags:

```ts
gh([
  "search", "issues",
  "--repo", `${REPO_OWNER}/${REPO_NAME}`,
  "--label", "promo",
  "--label", "submission",
  "--state", "open",
  "--sort", "created",
  "--order", "asc",
  "--limit", "100",
  "--json", "number,body,title,author",
])
```

Tested locally — no error, returns clean JSON.