### PR TITLE
chore: add Destructive Command Guard workflow

### DIFF
--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -1,0 +1,20 @@
+name: Destructive Command Guard
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Dicklesworthstone/destructive_command_guard/action@v0
+        with:
+          paths: .
+          fail-on: error
+          comment-on-pr: false

--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Dicklesworthstone/destructive_command_guard/action@v0
+      - uses: Dicklesworthstone/destructive_command_guard/action@v0.4.5
         with:
           paths: .
           fail-on: error


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for `Dicklesworthstone/destructive_command_guard/action@v0`
- scan the full repository on `push` and `pull_request`
- fail only on `error` findings and keep PR comments disabled for the initial rollout

## Notes
- this keeps the first-pass rollout conservative so we can review any findings in CI before tuning scope or severity
