### PR TITLE
chore: add Destructive Command Guard workflow

### DIFF
--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -1,0 +1,18 @@
+name: Destructive Command Guard
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Dicklesworthstone/destructive_command_guard/action@v0
+        with:
+          paths: .
+          fail-on: error
+          format: markdown

--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -11,8 +11,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: Dicklesworthstone/destructive_command_guard/action@v0
+      - uses: Dicklesworthstone/destructive_command_guard/action@v0.4.5
         with:
           paths: .
           fail-on: error
           format: markdown
+          comment-on-pr: false


### PR DESCRIPTION
Adds a GitHub Actions workflow that scans the full repository with Destructive Command Guard on push and pull_request.

- Comments are disabled initially.
- The scan fails only on error findings.
- The workflow is intentionally small and isolated.